### PR TITLE
Add 'post_type' instead of 'docu_post_type'

### DIFF
--- a/templates/docu-search-form.php
+++ b/templates/docu-search-form.php
@@ -13,6 +13,7 @@
 				<input type="text" name="s" placeholder="<?php _e( 'Search', 'docu' );?>"/>
 				<button id="docu-search-button" type="submit"/>
 				<input type="hidden" name="docu_post_type" value="doc" />
+				<input type="hidden" name="post_type" value="doc" />
 				<?php wp_nonce_field('docu_action','docu_nonce_field');?>
 			</div>
 


### PR DESCRIPTION
Add new hidden field 'post_type' so it will automatically filter the posts with doc post type. I think you don't have to use 'docu_post_type' field if you add this one.
